### PR TITLE
Allow buckling factors less than 1.

### DIFF
--- a/arpackbu.c
+++ b/arpackbu.c
@@ -735,8 +735,11 @@ void arpackbu(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
 		    &ncv,z,&dz,iparam,ipntr,workd,workl,&lworkl,&info));
 
     printf("sigma=%f,d[0]=%f\n\n",sigma,d[0]);
+
+
+/* Changed by Victor Kemp 2022-04-02 */
   
-    /*  if((5.>d[0]/sigma)||(50000.<d[0]/sigma)){
+  if((5.>d[0]/sigma)||(50000.<d[0]/sigma)){
 	if(iconverged<-4) {
 	printf("no convergence for the buckling factor; maybe no buckling occurs");
 	FORTRAN(stop,());
@@ -746,7 +749,10 @@ void arpackbu(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
 	--iconverged;
 	SFREE(z);SFREE(d);
 	}
-	else{iconverged=0;}*/
+	else{iconverged=0;}
+
+/* End of change */
+ 
      
     SFREE(resid);SFREE(workd);SFREE(workl);SFREE(select);SFREE(temp_array);
 


### PR DESCRIPTION
Re-enable search for sigma